### PR TITLE
fix a bug in replaceimages

### DIFF
--- a/jemdoc
+++ b/jemdoc
@@ -574,9 +574,9 @@ def replaceimages(b):
   r = re.compile(r'(?<!\\)\[img((?:\{.*?\}){,3})\s(.*?)(?:\s(.*?))?(?<!\\)\]',
            re.M + re.S)
   m = r.search(b)
-  s = re.compile(r'{(.*?)}', re.M + re.S)
+  res = re.compile(r'{(.*?)}', re.M + re.S)
   while m:
-    m1 = list(s.findall(m.group(1)))
+    m1 = list(res.findall(m.group(1)))
     m1 += ['']*(3 - len(m1))
 
     bits = []


### PR DESCRIPTION
If there are many images, s will be changed by the code in line 588 then the code will raise a error in the next loop. So I change s to res.